### PR TITLE
Fix capture parameter handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ $request
     ->setCapture(true) // If you set false, you can delay capturing.
 ;
 
-$product = new \Issei\Spike\Model\Product('my-product-00001'))
+$product = new \Issei\Spike\Model\Product('my-product-00001');
+$product
     ->setTitle('Product Name')
     ->setDescription('Description of Product.')
     ->setPrice(123.45, 'USD')
@@ -44,7 +45,7 @@ $product = new \Issei\Spike\Model\Product('my-product-00001'))
 ;
 
 // The product can be added any times.
-$request->addProduct($product); 
+$request->addProduct($product);
 
 /** @var $createdCharge \Issei\Spike\Model\Charge */
 $createdCharge = $spike->charge($request);
@@ -150,7 +151,7 @@ $request
 ;
 
 /** @var $charge \Issei\Spike\Model\Charge */
-$charge = $spike->charge($request); 
+$charge = $spike->charge($request);
 ```
 
 ### Find a token

--- a/src/Spike.php
+++ b/src/Spike.php
@@ -134,7 +134,7 @@ class Spike
             'card' => $request->getToken(),
             'amount'   => $request->getAmount() ? $request->getAmount()->getAmount() : null,
             'currency' => $request->getAmount() ? $request->getAmount()->getCurrency() : null,
-            'capture'  => $request->isCapture(),
+            'capture'  => $request->isCapture() ? 'true': 'false',
             'products' => json_encode($request->getProducts()),
         ]);
 

--- a/tests/SpikeTest.php
+++ b/tests/SpikeTest.php
@@ -240,7 +240,7 @@ class SpikeTest extends \PHPUnit_Framework_TestCase
                 'card' => $request->getToken()->getId(),
                 'amount' => $request->getAmount()->getAmount(),
                 'currency' => $request->getAmount()->getCurrency(),
-                'capture' => $request->isCapture(),
+                'capture'  => $request->isCapture() ? 'true': 'false',
                 'products' => json_encode($request->getProducts()),
             ])
             ->will($this->returnValue(new Response(200, json_encode(['charge-data']))))

--- a/tests/SpikeTest.php
+++ b/tests/SpikeTest.php
@@ -266,7 +266,7 @@ class SpikeTest extends \PHPUnit_Framework_TestCase
                 'card' => null,
                 'amount' => null,
                 'currency' => null,
-                'capture' => true,
+                'capture' => 'true',
                 'products' => json_encode([]),
             ])
             ->willReturn(new Response(200, json_encode(['charge-data'])))


### PR DESCRIPTION
- `capture` parameter when charge method is always treated as `true` by SPIKE due to the parameter handling was wrong in client side.
- Fix syntax on `README.md`

(Thank you for creating client API for SPIKE!)
