### PR TITLE
Upgrade guzzlehttp/guzzle dependency, other

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/bin/
 /vendor/
 /composer.phar
 /composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
     - composer install --dev --no-interaction
 
 script:
-    - vendor/bin/phpunit -c phpunit.xml.dist --coverage-clover=coverage.clover
+    - bin/phpunit -c phpunit.xml.dist --coverage-clover=coverage.clover
 
 after_script:
     - wget https://scrutinizer-ci.com/ocular.phar

--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,12 @@
         }
     ],
     "require": {
-        "php": ">= 5.4"
+        "php": ">= 5.5"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.4",
-        "guzzlehttp/guzzle": "~4.0",
-        "symfony/var-dumper": "~2.6"
+        "guzzlehttp/guzzle": "~6.2",
+        "phpunit/phpunit": "~4.8 || ~6.4",
+        "symfony/var-dumper": "2.8.*"
     },
     "autoload": {
         "psr-4": {
@@ -28,7 +28,14 @@
         }
     },
     "suggest": {
-        "guzzlehttp/guzzle": "Allows for implementation of the Guzzle ~4.0 HTTP client"
+        "guzzlehttp/guzzle": "Allows for implementation of the Guzzle ~6.2 HTTP client"
+    },
+    "config": {
+        "bin-dir": "bin",
+        "platform": {
+            "php": "5.5.0"
+        },
+        "sort-packages": true
     },
     "extra": {
         "branch-alias": {

--- a/res/example/definition.php.dist
+++ b/res/example/definition.php.dist
@@ -1,4 +1,3 @@
 <?php
 
 define('API_SECRET', 'enter_your_api_secret');
-define('CARD_TOKEN', 'enter_your_card_token');

--- a/src/Http/Client/GuzzleHttpClient.php
+++ b/src/Http/Client/GuzzleHttpClient.php
@@ -38,13 +38,11 @@ class GuzzleHttpClient implements ClientInterface
         ];
 
         if ('GET' !== $method) {
-            $options['body'] = $params;
+            $options['form_params'] = $params;
         }
 
-        $request = $this->client->createRequest($method, $url, $options);
-
         try {
-            $rawResponse = $this->client->send($request);
+            $rawResponse = $this->client->request($method, $url, $options);
         } catch (RequestException $e) {
             $rawResponse = $this->handleException($e);
         }

--- a/src/Spike.php
+++ b/src/Spike.php
@@ -131,7 +131,7 @@ class Spike
     public function charge(ChargeRequest $request)
     {
         $result = $this->request('POST', '/charges', [
-            'card'     => $request->getToken(),
+            'card'     => (string) $request->getToken(),
             'amount'   => $request->getAmount() ? $request->getAmount()->getAmount() : null,
             'currency' => $request->getAmount() ? $request->getAmount()->getCurrency() : null,
             'capture'  => $request->isCapture() ? 'true' : 'false',

--- a/tests/ChargeRequestTest.php
+++ b/tests/ChargeRequestTest.php
@@ -6,8 +6,9 @@ use Issei\Spike\ChargeRequest;
 use Issei\Spike\Model\Money;
 use Issei\Spike\Model\Product;
 use Issei\Spike\Model\Token;
+use PHPUnit\Framework\TestCase;
 
-class ChargeRequestTest extends \PHPUnit_Framework_TestCase
+class ChargeRequestTest extends TestCase
 {
     public function testTokenAccessors()
     {

--- a/tests/Converter/RecursiveObjectFactoryConverterTest.php
+++ b/tests/Converter/RecursiveObjectFactoryConverterTest.php
@@ -4,6 +4,7 @@ namespace Issei\Spike\Tests\Converter;
 
 use Issei\Spike\Converter\RecursiveObjectFactoryConverter;
 use Issei\Spike\Model\Factory\ObjectFactoryInterface;
+use PHPUnit\Framework\TestCase;
 
 class ConcreteFactoryA implements ObjectFactoryInterface
 {
@@ -30,7 +31,7 @@ class ConcreteFactoryB extends ConcreteFactoryA
     }
 }
 
-class RecursiveObjectFactoryConverterTest extends \PHPUnit_Framework_TestCase
+class RecursiveObjectFactoryConverterTest extends TestCase
 {
     private static $testData = [
         [

--- a/tests/Exception/RequestExceptionTest.php
+++ b/tests/Exception/RequestExceptionTest.php
@@ -3,8 +3,9 @@
 namespace Issei\Spike\Tests\Exception;
 
 use Issei\Spike\Exception\RequestException;
+use PHPUnit\Framework\TestCase;
 
-class RequestExceptionTest extends \PHPUnit_Framework_TestCase
+class RequestExceptionTest extends TestCase
 {
     public function testConstructor()
     {

--- a/tests/Http/Client/CurlClientTest.php
+++ b/tests/Http/Client/CurlClientTest.php
@@ -3,8 +3,9 @@
 namespace Spike\Tests\Http\Client;
 
 use Issei\Spike\Http\Client\CurlClient;
+use PHPUnit\Framework\TestCase;
 
-class CurlClientTest extends \PHPUnit_Framework_TestCase
+class CurlClientTest extends TestCase
 {
     /**
      * @var CurlClient

--- a/tests/Http/Client/GuzzleHttpClientTest.php
+++ b/tests/Http/Client/GuzzleHttpClientTest.php
@@ -6,11 +6,12 @@ use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Exception\RequestException;
 use Issei\Spike\Http\Client\GuzzleHttpClient;
 use GuzzleHttp\ClientInterface;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Issei\Spike\Http\Response;
 
-class GuzzleHttpClientTest extends \PHPUnit_Framework_TestCase
+class GuzzleHttpClientTest extends TestCase
 {
     private $client;
     private $SUT;

--- a/tests/Model/ChargeTest.php
+++ b/tests/Model/ChargeTest.php
@@ -7,8 +7,9 @@ use Issei\Spike\Model\Charge;
 use Issei\Spike\Model\Dispute;
 use Issei\Spike\Model\Money;
 use Issei\Spike\Model\Refund;
+use PHPUnit\Framework\TestCase;
 
-class ChargeTest extends \PHPUnit_Framework_TestCase
+class ChargeTest extends TestCase
 {
     public function testToString()
     {

--- a/tests/Model/DisputeTest.php
+++ b/tests/Model/DisputeTest.php
@@ -4,8 +4,9 @@ namespace Issei\Spike\Tests\Model;
 
 use Issei\Spike\Model\Dispute;
 use Issei\Spike\Model\Money;
+use PHPUnit\Framework\TestCase;
 
-class DisputeTest extends \PHPUnit_Framework_TestCase
+class DisputeTest extends TestCase
 {
     public function testAccessors()
     {

--- a/tests/Model/Factory/CardFactoryTest.php
+++ b/tests/Model/Factory/CardFactoryTest.php
@@ -3,8 +3,9 @@
 namespace Issei\Spike\Tests\Model\Factory;
 
 use Issei\Spike\Model\Factory\CardFactory;
+use PHPUnit\Framework\TestCase;
 
-class CardFactoryTest extends \PHPUnit_Framework_TestCase
+class CardFactoryTest extends TestCase
 {
     /**
      * @var CardFactory

--- a/tests/Model/Factory/ChargeFactoryTest.php
+++ b/tests/Model/Factory/ChargeFactoryTest.php
@@ -7,8 +7,9 @@ use Issei\Spike\Model\Dispute;
 use Issei\Spike\Model\Factory\ChargeFactory;
 use Issei\Spike\Model\Money;
 use Issei\Spike\Model\Refund;
+use PHPUnit\Framework\TestCase;
 
-class ChargeFactoryTest extends \PHPUnit_Framework_TestCase
+class ChargeFactoryTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject

--- a/tests/Model/Factory/DisputeFactoryTest.php
+++ b/tests/Model/Factory/DisputeFactoryTest.php
@@ -4,8 +4,9 @@ namespace Issei\Spike\Tests\Model\Factory;
 
 use Issei\Spike\Model\Factory\DisputeFactory;
 use Issei\Spike\Model\Money;
+use PHPUnit\Framework\TestCase;
 
-class DisputeFactoryTest extends \PHPUnit_Framework_TestCase
+class DisputeFactoryTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject

--- a/tests/Model/Factory/ObjectListFactoryTest.php
+++ b/tests/Model/Factory/ObjectListFactoryTest.php
@@ -3,8 +3,9 @@
 namespace Issei\Spike\Tests\Model\Factory;
 
 use Issei\Spike\Model\Factory\ObjectListFactory;
+use PHPUnit\Framework\TestCase;
 
-class ObjectListFactoryTest extends \PHPUnit_Framework_TestCase
+class ObjectListFactoryTest extends TestCase
 {
     /**
      * @var ObjectListFactory

--- a/tests/Model/Factory/RefundFactoryTest.php
+++ b/tests/Model/Factory/RefundFactoryTest.php
@@ -4,8 +4,9 @@ namespace Issei\Spike\Tests\Model\Factory;
 
 use Issei\Spike\Model\Factory\RefundFactory;
 use Issei\Spike\Model\Money;
+use PHPUnit\Framework\TestCase;
 
-class RefundFactoryTest extends \PHPUnit_Framework_TestCase
+class RefundFactoryTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject

--- a/tests/Model/Factory/TokenFactoryTest.php
+++ b/tests/Model/Factory/TokenFactoryTest.php
@@ -4,8 +4,9 @@ namespace Issei\Spike\Tests\Model\Factory;
 
 use Issei\Spike\Model\Card;
 use Issei\Spike\Model\Factory\TokenFactory;
+use PHPUnit\Framework\TestCase;
 
-class TokenFactoryTest extends \PHPUnit_Framework_TestCase
+class TokenFactoryTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject

--- a/tests/Model/MoneyTest.php
+++ b/tests/Model/MoneyTest.php
@@ -3,8 +3,9 @@
 namespace Issei\Spike\Tests\Model;
 
 use Issei\Spike\Model\Money;
+use PHPUnit\Framework\TestCase;
 
-class MoneyTest extends \PHPUnit_Framework_TestCase
+class MoneyTest extends TestCase
 {
     public function testAccessors()
     {

--- a/tests/Model/ObjectListTest.php
+++ b/tests/Model/ObjectListTest.php
@@ -3,8 +3,9 @@
 namespace Issei\Spike\Tests\Model;
 
 use Issei\Spike\Model\ObjectList;
+use PHPUnit\Framework\TestCase;
 
-class ObjectListTest extends \PHPUnit_Framework_TestCase
+class ObjectListTest extends TestCase
 {
     public function testGeneral()
     {

--- a/tests/Model/ProductTest.php
+++ b/tests/Model/ProductTest.php
@@ -4,8 +4,9 @@ namespace Issei\Spike\Tests\Model;
 
 use Issei\Spike\Model\Money;
 use Issei\Spike\Model\Product;
+use PHPUnit\Framework\TestCase;
 
-class ProductTest extends \PHPUnit_Framework_TestCase
+class ProductTest extends TestCase
 {
     public function testJsonSerialize()
     {

--- a/tests/Model/RefundTest.php
+++ b/tests/Model/RefundTest.php
@@ -4,8 +4,9 @@ namespace Issei\Spike\Tests\Model;
 
 use Issei\Spike\Model\Money;
 use Issei\Spike\Model\Refund;
+use PHPUnit\Framework\TestCase;
 
-class RefundTest extends \PHPUnit_Framework_TestCase
+class RefundTest extends TestCase
 {
     public function testCreatedAccessors()
     {

--- a/tests/Model/TokenTest.php
+++ b/tests/Model/TokenTest.php
@@ -3,8 +3,9 @@
 namespace Issei\Spike\Tests\Model;
 
 use Issei\Spike\Model\Token;
+use PHPUnit\Framework\TestCase;
 
-class TokenTest extends \PHPUnit_Framework_TestCase
+class TokenTest extends TestCase
 {
     public function testToString()
     {

--- a/tests/SpikeTest.php
+++ b/tests/SpikeTest.php
@@ -12,8 +12,9 @@ use Issei\Spike\Model\Product;
 use Issei\Spike\Model\Token;
 use Issei\Spike\Spike;
 use Issei\Spike\TokenRequest;
+use PHPUnit\Framework\TestCase;
 
-class SpikeTest extends \PHPUnit_Framework_TestCase
+class SpikeTest extends TestCase
 {
     const SECRET = '_SECRET_';
 

--- a/tests/TokenRequestTest.php
+++ b/tests/TokenRequestTest.php
@@ -3,8 +3,9 @@
 namespace Issei\Spike\Tests;
 
 use Issei\Spike\TokenRequest;
+use PHPUnit\Framework\TestCase;
 
-class TokenRequestTest extends \PHPUnit_Framework_TestCase
+class TokenRequestTest extends TestCase
 {
     public function testSetCardNumber()
     {

--- a/tests/Util/DateTimeUtilTest.php
+++ b/tests/Util/DateTimeUtilTest.php
@@ -3,8 +3,9 @@
 namespace Issei\Spike\Tests\Util;
 
 use Issei\Spike\Util\DateTimeUtil;
+use PHPUnit\Framework\TestCase;
 
-class DateTimeUtilTest extends \PHPUnit_Framework_TestCase
+class DateTimeUtilTest extends TestCase
 {
     /**
      * @var \DateTime


### PR DESCRIPTION
- Guzzle base http client now depends on ~6.2 of `guzzlehttp/guzzle`

thereby:

- Drop PHP 5.4 support (minimum version it supports is now 5.5 and newer)